### PR TITLE
get work area from the primary display

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,7 +41,7 @@ function patcher(obj, live, method, original, patch) {
     eval(`${live}.${method} = ${newBody}`);
 }
 
-const getMessageTraySize = () => ({ width, height } = Main.layoutManager.getWorkAreaForMonitor(global.display.get_current_monitor()));
+const getMessageTraySize = () => ({ width, height } = Main.layoutManager.getWorkAreaForMonitor(global.display.get_primary_monitor()));
 
 const originalShow = MessageTray.prototype._showNotification;
 const originalHide = MessageTray.prototype._hideNotification;


### PR DESCRIPTION
Fix for issue #6 

Just changed so the display layout grabbed is from the primary display and not the current focused one. Tested with my own dual monitor setup and now the notifications display in the right place