### PR TITLE
Updated the "shell-version" array in metadata.json to include "49".

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "description": "Configure notification banner position and animation to your liking.\nVersion 9: Gnome 45 changes by mannjani@github\nVersion 10: mannjani@github added a test button inside prefs",
   "uuid": "notification-banner-reloaded@marcinjakubowski.github.com",
   "shell-version": [
-    "45", "46", "47", "48"
+    "45", "46", "47", "48", "49"
   ],
   "url": "https://github.com/marcinjakubowski/notification-position-reloaded",
   "settings-schema": "org.gnome.shell.extensions.notification-banner-reloaded"


### PR DESCRIPTION
Updated the "shell-version" array in metadata.json to include "49", as it appeared to be the only thing preventing this extension from working on GNOME 49. Tested on my personal workstation, works flawlessly.